### PR TITLE
Add command for disabling Hotspare PSU

### DIFF
--- a/drac_config
+++ b/drac_config
@@ -174,6 +174,9 @@ while [ $# -ne 0 ]; do
         "enableipmi")
             sh $libdir/ipmi.sh
             ;;
+        "disablehotspare")
+            sh $libdir/psu_redundancy.sh
+            ;;
         *)
             echo "Uknown server action specified"
             ;;

--- a/drac_config
+++ b/drac_config
@@ -6,36 +6,38 @@ cat << EOF
 Usage: drac_confing action server...
  action - action to perform:
   # Server access
-  view       - connect to KVM
+  view            - connect to KVM
 
   # DRAC management
-  racreset   - restart DRAC
-  getsel     - get DRAC sel
-  clrsel     - clear DRAC sel
-  monuser    - configure monitoring user and its password
-  rootpass   - set root user password
+  racreset        - restart DRAC
+  getsel          - get DRAC sel
+  clrsel          - clear DRAC sel
+  monuser         - configure monitoring user and its password
+  rootpass        - set root user password
+  enableipmi      - enable IPMI on the DRAC
+  disablehotspare - disable PSU hotspare
 
   # Power management
-  powerup    - power on
-  powerdown  - power off
-  hardreset  - hard reset
+  powerup         - power on
+  powerdown       - power off
+  hardreset       - hard reset
 
   # RAID (only iDRAC7 and 8)
-  createraid - build a RAID1 of 2 first disks
-  deleteraid - delete any existing RAIDs
+  createraid      - build a RAID1 of 2 first disks
+  deleteraid      - delete any existing RAIDs
 
   # DRAC deployment
-  base       - configure all base settings: NTP, SNMP.
-               You can use DC environment variable to deploy settings for
-               a particular datacenter.
-  setconsole - configure virtual console access
+  base            - configure all base settings: NTP, SNMP.
+                    You can use DC environment variable to deploy settings for
+                    a particular datacenter.
+  setconsole      - configure virtual console access
 
   # SSL operations. Reuqires IG ca-utils in in the same directory as
   # drac_config is deployed.
-  fullssl    - perform full ssl deployment
-  resetssl   - reset SSL to default settings
-  requestssl - configure ssl settings and create a CSR
-  deployssl  - deploy signed cert
+  fullssl         - perform full ssl deployment
+  resetssl        - reset SSL to default settings
+  requestssl      - configure ssl settings and create a CSR
+  deployssl       - deploy signed cert
 
  server - one or more servers to connect to
 EOF

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -68,6 +68,9 @@ EOF
 <Attribute Name="WebServer.1#TLSProtocol">TLS 1.2 Only</Attribute>
 <Attribute Name="WebServer.1#CustomCipherString">ECDH+AESGCM:DH+AESGCM:ECDH+AES256:RSA+AESGCM:RSA+AES:!DH+AES256:CDH+AES128:!DH+AES:!aNULL:!MD5:!DSS</Attribute>
 </Component>
+<Component FQDD="System.Embedded.1">
+<Attribute Name="ServerPwr.1#PSRapidOn">Disabled</Attribute>
+</Component>
 </SystemConfiguration>
 EOF
         $racadm set -f $tf -t xml

--- a/lib/psu_redundancy.sh
+++ b/lib/psu_redundancy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+case "$model" in
+    iDRAC[789])
+        $racadm set System.Power.Hotspare.Enable 0
+    ;;
+    *)
+        echo "Can not change PSU settings on $host because of its hardware model '$model'!"
+    ;;
+esac
+


### PR DESCRIPTION
This PR adds the disablehotspare command to cause both PSUs to be used as well as add it to the base profile, since this is something we want in every server. 