### PR TITLE
Add command to set the iDRAC Webserver name

### DIFF
--- a/drac_config
+++ b/drac_config
@@ -14,6 +14,7 @@ Usage: drac_confing action server...
   clrsel     - clear DRAC sel
   monuser    - configure monitoring user and its password
   rootpass   - set root user password
+  setwebname - set the webserver name
 
   # Power management
   powerup    - power on
@@ -173,6 +174,10 @@ while [ $# -ne 0 ]; do
             ;;
         "enableipmi")
             sh $libdir/ipmi.sh
+            ;;
+        "setwebname")
+            export RACADM
+            sh $libdir/webservername.sh
             ;;
         *)
             echo "Uknown server action specified"

--- a/lib/webservername.sh
+++ b/lib/webservername.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# In the case of setting the Webserver name, we must use an IP address, because
+# using the hostname always returns a 400 error.
+# As the default $racadm already contains the hostname, we must use a custom
+# one.
+case "$model" in
+    iDRAC[89])
+        IP=$(getent hosts "$host" | awk '{ print $1 }')
+        $RACADM -u ${USER} -p ${PASS} -r $IP set idrac.webserver.ManualDNSEntry "$host"
+    ;;
+    *)
+        echo "This iDRAC model doesn't support setting the Webserver name"
+    ;;
+esac


### PR DESCRIPTION
Newer iDRAC models had a patched CVE that requires all iDRACs to have a webserver name set that matches the hostname being used in the browser URL.

This command simplifies this process.